### PR TITLE
Fixed create_cfg

### DIFF
--- a/packer/packer.py
+++ b/packer/packer.py
@@ -123,7 +123,8 @@ class Packer(object):
         config.set(cat, 'output-plist', 'sprite.plist')
         config.set(cat, 'width', '1024')
         config.set(cat, 'height', '1024')
-        config.set(cat, 'aglorithm', 'simple')  
+        config.set(cat, 'algorithm', 'simple')
+        config.set(cat, 'padding', '0')
 
         with open(file_path, 'wb') as configfile:
             config.write(configfile)


### PR DESCRIPTION
I think that the `.cfg` generated with the `-n` flag was wrong.  
`algorithm` was misspelled and `padding` was missing
